### PR TITLE
Add CLAUDE.md with git workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Claude Instructions for austin-city-tours
+
+## Git Workflow
+
+- **Never commit directly to `main`**. All changes must be made on a feature branch.
+- Branch naming: `type/short-description` — e.g. `fix/booking-validation`, `feat/new-tour`, `chore/update-deps`
+- When starting any task that involves code changes, create a branch first:
+  ```bash
+  git checkout -b type/description
+  ```
+- When done, push the branch and open a PR against `main`:
+  ```bash
+  git push origin type/description
+  gh pr create --base main
+  ```
+- Do not push to `main` directly, even after a rebase.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to enforce branch-based workflow for Claude Code sessions
- Requires all changes on a feature branch with a PR before merging to `main`
- Includes branch naming convention and the exact commands to follow

## Test plan

- [ ] Verify `CLAUDE.md` is picked up by Claude Code in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)